### PR TITLE
Remove Bintray integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -11,13 +10,11 @@ buildscript {
 plugins {
     id "java"
     id "org.jetbrains.kotlin.jvm" version "1.4.30"
-    id "com.jfrog.bintray" version "1.7.3"
     id "maven-publish"
 }
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 

--- a/buildsystem/ci.gradle
+++ b/buildsystem/ci.gradle
@@ -59,13 +59,6 @@ artifacts {
     archives sourcesJar
 }
 
-Properties properties = new Properties()
-try {
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-} catch (FileNotFoundException ex) {
-    logger.warn('FileNotFoundException: local.properties file not found. Upload to bintray not possible.')
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -75,27 +68,6 @@ publishing {
                 def root = asNode()
                 root.children().last() + pomConfig
             }
-        }
-    }
-}
-
-bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
-    configurations = ['archives']
-    pkg {
-        repo = bintrayRepo
-        name = bintrayName
-        desc = libraryDescription
-        websiteUrl = siteUrl
-        vcsUrl = gitUrl
-        licenses = allLicenses
-        dryRun = false
-        publish = true
-        override = false
-        publicDownloadNumbers = true
-        version {
-            desc = libraryDescription
         }
     }
 }


### PR DESCRIPTION
Bintray has been shut down in May 2021. More information can be found here:
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/