### PR TITLE
Use KSP instead of KAPT when generating Moshi models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 plugins {
     id "java"
     id "org.jetbrains.kotlin.jvm" version "1.5.30"
-    id "org.jetbrains.kotlin.kapt" version "1.5.30"
+    id "com.google.devtools.ksp" version "1.5.30-1.0.0"
     id "maven-publish"
     id "com.github.ben-manes.versions" version "0.39.0"
     id 'com.autonomousapps.dependency-analysis' version "0.76.0"
@@ -49,5 +49,5 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
     api 'com.squareup.retrofit2:retrofit:2.9.0'
     api 'com.squareup.moshi:moshi-kotlin:1.12.0'
-    kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.12.0'
+    ksp 'dev.zacsweers.moshix:moshi-ksp:0.14.0'
 }


### PR DESCRIPTION
Please, merge the `api-simplification` branch before merging this.